### PR TITLE
DOC: fix incorrect documentation

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11443,7 +11443,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @doc(position="first", klass=_shared_doc_kwargs["klass"])
     def first_valid_index(self) -> Hashable | None:
         """
-        Return index for {position} non-NA value or None, if no NA value is found.
+        Return index for {position} non-NA value or None, if no non-NA value is found.
 
         Returns
         -------


### PR DESCRIPTION
first_valid_index() returns None if no non-NA values are found.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
