### PR TITLE
fix URL redirect

### DIFF
--- a/web/pandas/about/index.md
+++ b/web/pandas/about/index.md
@@ -54,7 +54,7 @@ This will help ensure the success of development of _pandas_ as a world-class op
   series without losing data;
 
 - Highly **optimized for performance**, with critical code paths written in
-  [Cython](http://www.cython.org/) or C.
+  [Cython](https://cython.org) or C.
 
 - Python with *pandas* is in use in a wide variety of **academic and
   commercial** domains, including Finance, Neuroscience, Economics,


### PR DESCRIPTION
http://www.cython.org/ -> https://cython.org

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
